### PR TITLE
Replace hbmqtt with amqtt

### DIFF
--- a/hss_server/mqtt.py
+++ b/hss_server/mqtt.py
@@ -12,8 +12,8 @@ import logging
 import json
 import asyncio
 
-from hbmqtt.client import MQTTClient, ClientException
-from hbmqtt.mqtt.constants import QOS_0
+from amqtt.client import MQTTClient, ClientException
+from amqtt.mqtt.constants import QOS_0
 
 # -----------------------------------------------------------------------------
 # class Mqtt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hbmqtt>=0.9.6
+amqtt>=0.10.0
 requests>=2.22.0
 appdirs>=1.4.3
 gitpython>=3.1.3

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-       'hbmqtt',
+       'amqtt',
        'requests',
        'appdirs',
        'GitPython',


### PR DESCRIPTION
Hello,

I was trying to install and run hss-server and failed, because python complained about a non-existing packet "websockets.protocol". Turns out the client and server component in there have been declared legacy. And it appears that it is hbmqtt which uses these legacy components. And it also turns out that hbmqtt is no longer actively maintained so it has not been updated.

There is a module named amqtt (by Yakifo) that can be found on GitHub under https://github.com/Yakifo/amqtt , that is a fork of hbmqtt and thus is API-compatible, which, however, has made the switch away from the legacy components. Thusly, I suggest switching over to amqtt.

This is the first time I make a pull request, so bear with me if I dide something wrong, but from what I can see, this should fix it, right?